### PR TITLE
Add `pre .code` to CSS selectors for dark mode color

### DIFF
--- a/public_html/assets/scss/_nf-core.scss
+++ b/public_html/assets/scss/_nf-core.scss
@@ -307,9 +307,7 @@ bg-code {
   border-radius: 3px;
   padding: 12px 15px;
   font-size: 14px;
-  code {
-    border: 1px solid $gray-300;
-  }
+  border: 1px solid $gray-300;
 }
 
 // nav
@@ -478,14 +476,6 @@ footer a:active {
 .main-content .module h4::before {
   padding-top: 0px;
   margin-top: 0px;
-}
-.main-content pre {
-  border-radius: 3px;
-  padding: 12px 15px;
-  font-size: 14px;
-  code {
-    border: 1px solid $gray-300;
-  }
 }
 
 .header-link {

--- a/public_html/assets/scss/nf-core-dark.scss
+++ b/public_html/assets/scss/nf-core-dark.scss
@@ -104,7 +104,9 @@ $nf-core-color: $nf-core-color-alt;
 }
 
 code,
-.code {
+.code,
+pre code,
+pre .code {
   color: $warning;
 }
 .card code {


### PR DESCRIPTION
Should hopefully fix this: https://nf-co.re/mhcquant/2.3.0/usage

<img width="699" alt="image" src="https://user-images.githubusercontent.com/465550/161998831-92f7ff9d-5064-4709-a8e0-dd217be93019.png">


<a href="https://gitpod.io/#https://github.com/ewels/nf-co.re/pull/3"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

