### PR TITLE
Pipeline health: remove array index strings

### DIFF
--- a/public_html/pipeline_health.php
+++ b/public_html/pipeline_health.php
@@ -486,7 +486,7 @@ class RepoHealth {
                     'enforce_admins' => false,
                     'required_status_checks' => [
                         'strict' => false,
-                        'contexts' => $contexts,
+                        'contexts' => array_values($contexts),
                     ],
                     'required_pull_request_reviews' => [
                         'dismiss_stale_reviews' => false,


### PR DESCRIPTION
Hoping that this change might fix this error when updating required CI checks:

---

<div class="alert alert-danger m-3" style="box-sizing: border-box; position: relative; padding: 1rem; margin: 1rem !important; border: 1px solid rgb(139, 46, 36); border-radius: 0.25rem; color: rgb(238, 130, 119); background-color: rgb(116, 38, 30);"><strong class="me-2" style="box-sizing: border-box; font-weight: 600; margin-right: 0.5rem !important;">Error with GitHub API</strong><span> </span>There was a problem with the following URL:<span> </span><code class="me-2" style="box-sizing: border-box; font-family: SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 0.875em; direction: ltr; unicode-bidi: bidi-override; color: rgb(243, 156, 18); overflow-wrap: break-word; background-color: rgba(59, 59, 59, 0.75); border-radius: 3px; padding: 2px 6px; margin-right: 0.5rem !important;">https://api.github.com/repos/nf-core/airrflow/branches/master/protection</code><span> </span>(<code style="box-sizing: border-box; font-family: SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 0.875em; direction: ltr; unicode-bidi: bidi-override; color: rgb(243, 156, 18); overflow-wrap: break-word; background-color: rgba(59, 59, 59, 0.75); border-radius: 3px; padding: 2px 6px;">PUT</code>)<details style="box-sizing: border-box;"><pre style="box-sizing: border-box; font-family: var(--bs-font-monospace); font-size: 0.875em; direction: ltr; unicode-bidi: bidi-override; display: block; margin-top: 0px; margin-bottom: 1rem; overflow: auto; color: rgb(34, 34, 34);">[
    "HTTP\/1.1 422 Unprocessable Entity",
    "Server: GitHub.com",
    "Date: Fri, 29 Apr 2022 10:13:39 GMT",
    "Content-Type: application\/json; charset=utf-8",
    "Content-Length: 657",
    "X-OAuth-Scopes: notifications, read:org, repo, user, workflow",
    "X-Accepted-OAuth-Scopes:",
    "X-GitHub-Media-Type: github.mercy-preview; param=luke-cage-preview; format=json",
    "X-RateLimit-Limit: 5000",
    "X-RateLimit-Remaining: 4695",
    "X-RateLimit-Reset: 1651228300",
    "X-RateLimit-Used: 305",
    "X-RateLimit-Resource: core",
    "Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
    "Access-Control-Allow-Origin: *",
    "Strict-Transport-Security: max-age=31536000; includeSubdomains; preload",
    "X-Frame-Options: deny",
    "X-Content-Type-Options: nosniff",
    "X-XSS-Protection: 0",
    "Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin",
    "Content-Security-Policy: default-src 'none'",
    "Vary: Accept-Encoding, Accept, X-Requested-With",
    "X-GitHub-Request-Id: E35A:A0BA:3AA108:3EACE9:626BBA53",
    "connection: close"
]</pre><pre style="box-sizing: border-box; font-family: var(--bs-font-monospace); font-size: 0.875em; direction: ltr; unicode-bidi: bidi-override; display: block; margin-top: 0px; margin-bottom: 1rem; overflow: auto; color: rgb(34, 34, 34);">{
    "enforce_admins": false,
    "required_status_checks": {
        "strict": false,
        "contexts": {
            "0": "Prettier",
            "1": "EditorConfig",
            "2": "nf-core",
            "3": "Run pipeline with test data",
            "7": "Run workflow test with different profiles (test_tcr)"
        }
    },
    "required_pull_request_reviews": {
        "dismiss_stale_reviews": false,
        "require_code_owner_reviews": false,
        "required_approving_review_count": 2
    },
    "restrictions": null
}</pre></details></div>

---

NB:

```json
        "contexts": {
            "0": "Prettier",
            "1": "EditorConfig",
            "2": "nf-core",
            "3": "Run pipeline with test data",
            "7": "Run workflow test with different profiles (test_tcr)"
        }
```

which I _think_ should be:

```json
        "contexts": [
            "Prettier",
            "EditorConfig",
            "nf-core",
            "Run pipeline with test data",
            "Run workflow test with different profiles (test_tcr)"
        ]
```

(or at least consecutive numbers..?!)

<a href="https://gitpod.io/#https://github.com/ewels/nf-co.re/pull/5"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

